### PR TITLE
Fix QodotMap builds outside of scene tree & optional blocking builds

### DIFF
--- a/addons/qodot/src/nodes/qodot_map.gd
+++ b/addons/qodot/src/nodes/qodot_map.gd
@@ -28,6 +28,7 @@ var default_material := SpatialMaterial.new()
 var uv_unwrap_texel_size := 1.0
 var print_profiling_data := false
 var use_trenchbroom_group_hierarchy := false
+var block_until_complete := false
 var tree_attach_batch_size := 16
 var set_owner_batch_size := 16
 
@@ -250,7 +251,7 @@ func run_build_steps(post_attach := false) -> void:
 		build_step_index += 1
 
 		var scene_tree := get_tree()
-		if scene_tree:
+		if scene_tree and not block_until_complete:
 			yield(scene_tree.create_timer(YIELD_DURATION), YIELD_SIGNAL)
 
 	if post_attach:
@@ -950,7 +951,7 @@ func add_children() -> void:
 				return
 
 		var scene_tree := get_tree()
-		if scene_tree:
+		if scene_tree and not block_until_complete:
 			yield(scene_tree.create_timer(YIELD_DURATION), YIELD_SIGNAL)
 
 func add_children_complete():
@@ -973,7 +974,7 @@ func set_owners():
 				return
 
 		var scene_tree := get_tree()
-		if scene_tree:
+		if scene_tree and not block_until_complete:
 			yield(scene_tree.create_timer(YIELD_DURATION), YIELD_SIGNAL)
 
 func set_owners_complete():

--- a/addons/qodot/src/nodes/qodot_map.gd
+++ b/addons/qodot/src/nodes/qodot_map.gd
@@ -249,7 +249,9 @@ func run_build_steps(post_attach := false) -> void:
 		emit_signal("build_progress", build_step[0], float(build_step_index + 1) / float(build_step_count))
 		build_step_index += 1
 
-		yield(get_tree().create_timer(YIELD_DURATION), YIELD_SIGNAL)
+		var scene_tree := get_tree()
+		if scene_tree:
+			yield(scene_tree.create_timer(YIELD_DURATION), YIELD_SIGNAL)
 
 	if post_attach:
 		build_complete()
@@ -946,7 +948,10 @@ func add_children() -> void:
 			else:
 				add_children_complete()
 				return
-		yield(get_tree().create_timer(YIELD_DURATION), YIELD_SIGNAL)
+
+		var scene_tree := get_tree()
+		if scene_tree:
+			yield(scene_tree.create_timer(YIELD_DURATION), YIELD_SIGNAL)
 
 func add_children_complete():
 	stop_profile('add_children')
@@ -966,7 +971,10 @@ func set_owners():
 			else:
 				set_owners_complete()
 				return
-		yield(get_tree().create_timer(YIELD_DURATION), YIELD_SIGNAL)
+
+		var scene_tree := get_tree()
+		if scene_tree:
+			yield(scene_tree.create_timer(YIELD_DURATION), YIELD_SIGNAL)
 
 func set_owners_complete():
 	stop_profile('set_owners')


### PR DESCRIPTION
Scene tree isn't available when QodotMap is instantiated outside of a scene tree. In this case, use `Engine.get_main_loop()` to yield control to the engine to keep the editor responsive while building the map.

Using `Engine.get_main_loop()` in every scenario (even when the scene tree is available) causes the editor to crash. Using it as a fallback does not seem to have any problems, though.