### PR TITLE
Fix base classes and default values

### DIFF
--- a/addons/qodot/src/nodes/qodot_map.gd
+++ b/addons/qodot/src/nodes/qodot_map.gd
@@ -1016,6 +1016,11 @@ func apply_properties() -> void:
 						elif prop_default is Array:
 							properties[property] = prop_string.to_int()
 
+				# Assign properties not defined with defaults from the entity definition
+				for property in entity_definitions[classname].class_properties:
+					if not property in properties:
+						properties[property] = entity_definition.class_properties[property]
+
 		if 'properties' in entity_node:
 			entity_node.properties = properties
 

--- a/addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_file.gd
+++ b/addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_file.gd
@@ -108,18 +108,21 @@ func get_entity_definitions() -> Dictionary:
 	return res
 
 
-func _generate_base_class_list(entity_def : Resource) -> Array:
+func _generate_base_class_list(entity_def : Resource, visited_base_classes = []) -> Array:
 	var base_classes : Array = []
-
-	# End recursive search if no more base_classes
+	
+	visited_base_classes.append(entity_def.classname)
+	
+	 # End recursive search if no more base_classes
 	if len(entity_def.base_classes) == 0:
 		return base_classes
-
-	# Add base_classes at this level in the hierarchy
-	base_classes = entity_def.base_classes
-
-	# Traverse up to the next level of hierarchy
+	
+	# Traverse up to the next level of hierarchy, if not already visited
 	for base_class in entity_def.base_classes:
-		base_classes += _generate_base_class_list(base_class)
+		if not base_class.classname in visited_base_classes:
+			base_classes.append(base_class)
+			base_classes += _generate_base_class_list(base_class, visited_base_classes)
+		else:
+			push_error(str("Entity '", entity_def.classname,"' contains cycle/duplicate to Entity '", base_class.classname, "'"))
 
 	return base_classes

--- a/addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_file.gd
+++ b/addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_file.gd
@@ -123,6 +123,6 @@ func _generate_base_class_list(entity_def : Resource, visited_base_classes = [])
 			base_classes.append(base_class)
 			base_classes += _generate_base_class_list(base_class, visited_base_classes)
 		else:
-			push_error(str("Entity '", entity_def.classname,"' contains cycle/duplicate to Entity '", base_class.classname, "'"))
+			printerr(str("Entity '", entity_def.classname,"' contains cycle/duplicate to Entity '", base_class.classname, "'"))
 
 	return base_classes

--- a/addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_file.gd
+++ b/addons/qodot/src/resources/game-definitions/fgd/qodot_fgd_file.gd
@@ -81,7 +81,7 @@ func get_entity_definitions() -> Dictionary:
 			var class_properties := {}
 			var class_property_descriptions := {}
 
-			for base_class in entity_def.base_classes:
+			for base_class in _generate_base_class_list(entity_def):
 				for meta_property in base_class.meta_properties:
 					meta_properties[meta_property] = base_class.meta_properties[meta_property]
 
@@ -106,3 +106,20 @@ func get_entity_definitions() -> Dictionary:
 
 			res[ent.classname] = entity_def
 	return res
+
+
+func _generate_base_class_list(entity_def : Resource) -> Array:
+	var base_classes : Array = []
+
+	# End recursive search if no more base_classes
+	if len(entity_def.base_classes) == 0:
+		return base_classes
+
+	# Add base_classes at this level in the hierarchy
+	base_classes = entity_def.base_classes
+
+	# Traverse up to the next level of hierarchy
+	for base_class in entity_def.base_classes:
+		base_classes += _generate_base_class_list(base_class)
+
+	return base_classes


### PR DESCRIPTION
During the 'fetch_entity_definitions' build step, the qodot-plugin is only considering 1 level of base class hierarchy when merging properties into the entity. I believe FGD supports a multi-level hierarchy, so shouldn't all base classes be traversed while merging in properties?

In addition, when the 'apply_properties' build step is executed, only existing properties are evaluated - and properties defined in the entity definition are ignored.  Unassigned properties - at least in TrenchBroom - are assumed to be 'default' value.  Therefore, shouldn't missing/unassigned properties be set to the defaults defined in the entity definition?