### PR TITLE
Bump version number from 1.6.4 to 1.7.1

### DIFF
--- a/addons/qodot/plugin.cfg
+++ b/addons/qodot/plugin.cfg
@@ -3,5 +3,5 @@
 name="Qodot"
 description="Quake .map file support for Godot."
 author="Shifty"
-version="1.6.4"
+version="1.7.0"
 script="src/qodot_plugin.gd"

--- a/addons/qodot/plugin.cfg
+++ b/addons/qodot/plugin.cfg
@@ -3,5 +3,5 @@
 name="Qodot"
 description="Quake .map file support for Godot."
 author="Shifty"
-version="1.7.0"
+version="1.7.1"
 script="src/qodot_plugin.gd"


### PR DESCRIPTION
Right now, this repo is at least as up-to-date as the 1.7.0 release, though the internal plugin version number currently says 1.6.4 when downloaded from the repo:

![image](https://user-images.githubusercontent.com/47726614/134369009-ca12d692-acb1-43b2-a972-02f1c24365db.png)

I think the version bump is worth it since we now have additional user documentation in the README, and the ability to use multiple texture file-extensions thanks to Zaraka's work, which is a huge step above what's currently in the 1.7.0 release.

There doesn't need to be a big official 1.7.1 release, but we might as well make it so people can cross-reference version numbers correctly.